### PR TITLE
Update DTO to include chargingDisabledVehicles field.

### DIFF
--- a/src/main/java/uk/gov/caz/tariff/dto/Tariff.java
+++ b/src/main/java/uk/gov/caz/tariff/dto/Tariff.java
@@ -35,4 +35,7 @@ public class Tariff {
 
   @ApiModelProperty(value = "${swagger.model.descriptions.tariff.informationUrls}")
   InformationUrls informationUrls;
+  
+  @ApiModelProperty(value = "${swagger.model.descriptions.tariff.chargingDisabledVehicles}")
+  boolean chargingDisabledVehicles;
 }

--- a/src/main/java/uk/gov/caz/tariff/service/TariffRepository.java
+++ b/src/main/java/uk/gov/caz/tariff/service/TariffRepository.java
@@ -25,6 +25,7 @@ public class TariffRepository {
       + "charge.caz_name, "
       + "charge.caz_class, "
       + "charge.charge_identifier, "
+      + "charge.charging_disabled_vehicles, "
       + "link.emissions_url, "
       + "link.main_info_url, "
       + "link.pricing_url, "
@@ -88,6 +89,7 @@ public class TariffRepository {
           .name(rs.getString("caz_name"))
           .tariffClass(rs.getString("caz_class").charAt(0))
           .chargeIdentifier(rs.getString("charge_identifier"))
+          .chargingDisabledVehicles(rs.getBoolean("charging_disabled_vehicles"))
           .informationUrls(InformationUrls.builder()
               .becomeCompliant(rs.getString("become_compliant_url"))
               .hoursOfOperation(rs.getString("operation_hours_url"))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,7 @@ swagger:
       chargeIdentifier: Charge Identifier
       rates: Rates
       informationUrls: URLs information
+      chargingDisabledVehicles: Indicates if vehicles with 'DISABLED' tax class are chargeable under this tariff
     informationUrl:
       emissionsStandardsUrl: URL provided by zone operators, emissions standards
       mainInfoUrl: URL provided by zone operators, clean air zone

--- a/src/main/resources/db/changelog/changes/0010-1.0-create-charging-disabled-vehicles-column.yaml
+++ b/src/main/resources/db/changelog/changes/0010-1.0-create-charging-disabled-vehicles-column.yaml
@@ -5,10 +5,10 @@ databaseChangeLog:
       changes:
       - addColumn:
           comment: Add column to check if CAZ charging vehicles with a 'DISABLED' tax class.
-          tableName: T_TARIFF_DEFINITION
+          tableName: T_CHARGE_DEFINITION
           columns:
           - column:
-              name: CHARGING_DIASABLED_VEHICLES
+              name: CHARGING_DISABLED_VEHICLES
               type: boolean
   - changeSet:
       id: 0010.2.1.0
@@ -20,11 +20,11 @@ databaseChangeLog:
             endDelimiter: ;GO
             splitStatements: true
             sql:
-                UPDATE public.T_TARIFF_DEFINITION
-                SET CHARGING_DIASABLED_VEHICLES = FALSE
+                UPDATE public.T_CHARGE_DEFINITION
+                SET CHARGING_DISABLED_VEHICLES = FALSE
                 WHERE CHARGE_DEFINITION_ID = 1;
                 
-                UPDATE public.T_TARIFF_DEFINITION
-                SET CHARGING_DIASABLED_VEHICLES = TRUE
+                UPDATE public.T_CHARGE_DEFINITION
+                SET CHARGING_DISABLED_VEHICLES = TRUE
                 WHERE CHARGE_DEFINITION_ID = 2;
             stripComments: true

--- a/src/main/resources/db/changelog/changes/0010-1.0-create-charging-disabled-vehicles-column.yaml
+++ b/src/main/resources/db/changelog/changes/0010-1.0-create-charging-disabled-vehicles-column.yaml
@@ -1,0 +1,30 @@
+databaseChangeLog:
+  - changeSet:
+      id: 0010.1.1.0
+      author: informed
+      changes:
+      - addColumn:
+          comment: Add column to check if CAZ charging vehicles with a 'DISABLED' tax class.
+          tableName: T_TARIFF_DEFINITION
+          columns:
+          - column:
+              name: CHARGING_DIASABLED_VEHICLES
+              type: boolean
+  - changeSet:
+      id: 0010.2.1.0
+      author: informed
+      changes:
+        - sql:
+            comment: Update additionalInfo
+            dbms: postgresql
+            endDelimiter: ;GO
+            splitStatements: true
+            sql:
+                UPDATE public.T_TARIFF_DEFINITION
+                SET CHARGING_DIASABLED_VEHICLES = FALSE
+                WHERE CHARGE_DEFINITION_ID = 1;
+                
+                UPDATE public.T_TARIFF_DEFINITION
+                SET CHARGING_DIASABLED_VEHICLES = TRUE
+                WHERE CHARGE_DEFINITION_ID = 2;
+            stripComments: true


### PR DESCRIPTION
* VCCS-800 requires that vehicles whose tax class is `DISABLED` is not charged, if that CAZ chooses to do so.
* This requires a change to both the data tier and and the response object to include that field.