### PR TITLE
Set minibus charge in Leeds to 0

### DIFF
--- a/src/main/resources/db/changelog/changes/0016-1.0-leeds-tariff-minibus-update.yaml
+++ b/src/main/resources/db/changelog/changes/0016-1.0-leeds-tariff-minibus-update.yaml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: 0016.1.0
+      author: informed
+      changes:
+        - sql:
+            comment: Update minibus tariff for Leeds
+            dbms: postgresql
+            endDelimiter: ;GO
+            splitStatements: true
+            sql:
+                UPDATE public.t_tariff_definition
+                SET minibus_entrant_fee = 0.00
+                WHERE charge_definition_id = 2;
+            stripComments: true


### PR DESCRIPTION
Previously this was set to a tariff (12.50), however this was returning an incorrect result when fetching chargeable Clean Air Zones for unknown vehicles. As minibuses are chargeable under CAZ class C, then they should not have a charge associated with them in Leeds (as it is class B).