### PR TITLE
[CAZB-1969] mainInfoUrl data exposure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <artifactFinalName>${project.artifactId}-${project.version}</artifactFinalName>
 
-    <internal.libraries.version>2.12.3-SNAPSHOT</internal.libraries.version>
+    <internal.libraries.version>2.12.6-SNAPSHOT</internal.libraries.version>
 
     <codeCoverage.minCoveredRatio>1</codeCoverage.minCoveredRatio>
     <codeCoverage.classMaxMissedCount>0</codeCoverage.classMaxMissedCount>

--- a/src/main/java/uk/gov/caz/tariff/service/CleanAirZonesRepository.java
+++ b/src/main/java/uk/gov/caz/tariff/service/CleanAirZonesRepository.java
@@ -26,7 +26,8 @@ public class CleanAirZonesRepository {
       + "charge.active_charge_start_time, "
       + "charge.caz_operator_name, "
       + "link.boundary_url, "
-      + "link.exemption_url "
+      + "link.exemption_url, "
+      + "link.main_info_url "
       + "FROM t_charge_definition charge, t_caz_link_detail link "
       + "WHERE link.charge_definition_id = charge.charge_definition_id ";
 
@@ -60,6 +61,7 @@ public class CleanAirZonesRepository {
           .name(rs.getString("caz_name"))
           .boundaryUrl(URI.create(rs.getString("boundary_url")))
           .exemptionUrl(URI.create(rs.getString("exemption_url")))
+          .mainInfoUrl(URI.create(rs.getString("main_info_url")))
           .activeChargeStartDate(safelyGetActiveChargeStartDate(rs))
           .operatorName(rs.getString("caz_operator_name"))
           .build();

--- a/src/test/java/uk/gov/caz/tariff/controller/CleanAirZonesControllerTest.java
+++ b/src/test/java/uk/gov/caz/tariff/controller/CleanAirZonesControllerTest.java
@@ -35,6 +35,7 @@ class CleanAirZonesControllerTest {
   private static final String SOME_CLEAN_AIR_ZONE_ID = "dc1efcaf-a2cf-41ec-aa37-ea4b28a20a1d";
   private static LocalDate ACTIVE_CHARGE_START_DATE = LocalDate.of(2018, 10, 28);
   private static final String SOME_URL = "www.test.uk";
+  private static final String MAIN_INFO_URL = "www.main.info";
 
   @Mock
   private TariffRepository tariffRepository;
@@ -64,6 +65,7 @@ class CleanAirZonesControllerTest {
                 "https://www.birmingham.gov.uk/info/20076/pollution/1763/a_clean_air_zone_for_birmingham/3"))
             .exemptionUrl(URI.create("https://exemption.birmingham.gov.uk"))
             .activeChargeStartDate("2018-10-28")
+            .mainInfoUrl(URI.create(MAIN_INFO_URL))
             .build()
     );
   }
@@ -144,23 +146,26 @@ class CleanAirZonesControllerTest {
                 "https://www.birmingham.gov.uk/info/20076/pollution/"
                     + "1763/a_clean_air_zone_for_birmingham/3",
                 "https://exemption.birmingham.gov.uk",
+                MAIN_INFO_URL,
                 ACTIVE_CHARGE_START_DATE),
 
             caz("Leeds", "39e54ed8-3ed2-441d-be3f-38fc9b70c8d3",
                 "https://www.arcgis.com/home/webmap/viewer.html?webmap="
                     + "de0120ae980b473982a3149ab072fdfc&extent=-1.733%2c53.7378%2c-1.333%2c53.8621",
                 "https://exemption.leeds.gov.uk",
+                MAIN_INFO_URL,
                 ACTIVE_CHARGE_START_DATE)
         )).build();
   }
 
   private CleanAirZoneDto caz(String cazName, String cleanAirZoneId, String boundaryUrl,
-      String exemptionUrl, LocalDate activeChargeStartDate) {
+      String exemptionUrl, String mainInfoUrl, LocalDate activeChargeStartDate) {
     return CleanAirZoneDto.builder()
         .name(cazName)
         .cleanAirZoneId(UUID.fromString(cleanAirZoneId))
         .boundaryUrl(URI.create(boundaryUrl))
         .exemptionUrl(URI.create(exemptionUrl))
+        .mainInfoUrl(URI.create(mainInfoUrl))
         .activeChargeStartDate(activeChargeStartDate.format(DateTimeFormatter.ISO_DATE))
         .build();
   }

--- a/src/test/java/uk/gov/caz/tariff/service/CleanAirZonesRepositoryTest.java
+++ b/src/test/java/uk/gov/caz/tariff/service/CleanAirZonesRepositoryTest.java
@@ -33,8 +33,8 @@ class CleanAirZonesRepositoryTest {
       .fromString("dc1efcaf-a2cf-41ec-aa37-ea4b28a20a1d");
 
   private static final String SOME_URL = "www.test.uk";
-
   private static final String EXEMPTION_URL = "www.exemption.uk";
+  private static final String MAIN_INFO_URL = "www.main.info";
 
   private static final String LEEDS = "Leeds";
   private static final String LEEDS_OPERATOR_NAME = "Leeds City Council";
@@ -105,6 +105,8 @@ class CleanAirZonesRepositoryTest {
             return SOME_URL;
           case "exemption_url":
             return EXEMPTION_URL;
+          case "main_info_url":
+            return MAIN_INFO_URL;
           case "caz_operator_name":
             return LEEDS_OPERATOR_NAME;
         }
@@ -128,24 +130,26 @@ class CleanAirZonesRepositoryTest {
             caz("Birmingham", "0d7ab5c4-5fff-4935-8c4e-56267c0c9493",
                 "https://www.birmingham.gov.uk/info/20076/pollution/"
                     + "1763/a_clean_air_zone_for_birmingham/3",
-                "https://exemptions.birmingham.gov.uk",
+                "https://exemptions.birmingham.gov.uk", MAIN_INFO_URL,
                 ACTIVE_CHARGE_START_DATE, "Birmingham City Council"),
 
             caz("Leeds", "39e54ed8-3ed2-441d-be3f-38fc9b70c8d3",
                 "https://www.arcgis.com/home/webmap/viewer.html?webmap="
                     + "de0120ae980b473982a3149ab072fdfc&extent=-1.733%2c53.7378%2c-1.333%2c53.8621",
-                "https://exemptions.leeds.gov.uk",
+                "https://exemptions.leeds.gov.uk", MAIN_INFO_URL,
                 ACTIVE_CHARGE_START_DATE, "Leeds City Council")
         )).build().getCleanAirZones();
   }
 
   private CleanAirZoneDto caz(String cazName, String cleanAirZoneId, String boundaryUrl,
-      String exemptionUrl, LocalDate activeChargeStartDate, String operatorName) {
+      String exemptionUrl, String mainInfoUrl, LocalDate activeChargeStartDate,
+      String operatorName) {
     return CleanAirZoneDto.builder()
         .name(cazName)
         .cleanAirZoneId(UUID.fromString(cleanAirZoneId))
         .boundaryUrl(URI.create(boundaryUrl))
         .exemptionUrl(URI.create(exemptionUrl))
+        .mainInfoUrl(URI.create(mainInfoUrl))
         .activeChargeStartDate(activeChargeStartDate.format(DateTimeFormatter.ISO_DATE))
         .operatorName(operatorName)
         .build();
@@ -158,6 +162,7 @@ class CleanAirZonesRepositoryTest {
         .operatorName(LEEDS_OPERATOR_NAME)
         .boundaryUrl(URI.create(SOME_URL))
         .exemptionUrl(URI.create(EXEMPTION_URL))
+        .mainInfoUrl(URI.create(MAIN_INFO_URL))
         .activeChargeStartDate(ACTIVE_CHARGE_START_DATE.format(DateTimeFormatter.ISO_DATE))
         .build();
   }


### PR DESCRIPTION
Link to JIRA Card: https://eaflood.atlassian.net/browse/CAZB-1971

----

Introduced changes:
* Updated internal library version to include `mainInfoUrl` in `CleanAirZoneDto`
* Updated `CleanAirZonesRepository`
* Updated specs

----

Screenshot:

![Screenshot 2020-07-07 at 12 00 52](https://user-images.githubusercontent.com/4506633/86783352-7c1ead00-c060-11ea-9f48-62f5f122acf7.png)

