### PR TITLE
[CAZB-3394] Remove references to Leeds from tests

### DIFF
--- a/src/it/java/uk/gov/caz/tariff/controller/CleanAirZonesControllerTestIT.java
+++ b/src/it/java/uk/gov/caz/tariff/controller/CleanAirZonesControllerTestIT.java
@@ -40,7 +40,7 @@ class CleanAirZonesControllerTestIT {
 
   private static final String SOME_URL = "www.test.uk";
 
-  private static final String CLEAN_AIR_ZONE_ID = "dc1efcaf-a2cf-41ec-aa37-ea4b28a20a1d";
+  private static final String CLEAN_AIR_ZONE_ID = "5dd5c926-ed33-4a0a-b911-46324433e866";
 
   private static LocalDate ACTIVE_CHARGE_START_DATE = LocalDate.of(2018, 10, 28);
 
@@ -137,9 +137,9 @@ class CleanAirZonesControllerTestIT {
 
     return Optional.ofNullable(Tariff.builder()
         .cleanAirZoneId(UUID.fromString(CLEAN_AIR_ZONE_ID))
-        .name("Leeds")
-        .tariffClass('A')
-        .chargeIdentifier("LCC01")
+        .name("Bath")
+        .tariffClass('C')
+        .chargeIdentifier("BAT01")
         .activeChargeStartDate("2020-04-24")
         .informationUrls(informationUrls)
         .rates(rates)
@@ -155,11 +155,10 @@ class CleanAirZonesControllerTestIT {
                 "https://exemption.birmingham.gov.uk",
                 ACTIVE_CHARGE_START_DATE, "Birmingham City Council"),
 
-            caz("Leeds", "39e54ed8-3ed2-441d-be3f-38fc9b70c8d3",
-                "https://www.arcgis.com/home/webmap/viewer.html?webmap="
-                    + "de0120ae980b473982a3149ab072fdfc&extent=-1.733%2c53.7378%2c-1.333%2c53.8621",
-                "https://exemption.leeds.gov.uk",
-                ACTIVE_CHARGE_START_DATE, "Leeds City Council")
+            caz("Bath", "5dd5c926-ed33-4a0a-b911-46324433e866",
+                "http://www.bathnes.gov.uk/zonemaps",
+                "http://www.bathnes.gov.uk/BathCAZ",
+                ACTIVE_CHARGE_START_DATE, "Bath and North East Somerset Council")
         )).build();
   }
 

--- a/src/it/java/uk/gov/caz/tariff/controller/CleanAirZonesControllerTestIT.java
+++ b/src/it/java/uk/gov/caz/tariff/controller/CleanAirZonesControllerTestIT.java
@@ -157,7 +157,7 @@ class CleanAirZonesControllerTestIT {
 
             caz("Bath", "5dd5c926-ed33-4a0a-b911-46324433e866",
                 "http://www.bathnes.gov.uk/zonemaps",
-                "http://www.bathnes.gov.uk/BathCAZ",
+                "http://www.bathnes.gov.uk/CAZexemptions",
                 ACTIVE_CHARGE_START_DATE, "Bath and North East Somerset Council")
         )).build();
   }

--- a/src/it/resources/data/json/clean-air-zones.json
+++ b/src/it/resources/data/json/clean-air-zones.json
@@ -11,7 +11,7 @@
       "cleanAirZoneId": "5dd5c926-ed33-4a0a-b911-46324433e866",
       "name": "Bath",
       "boundaryUrl": "http://www.bathnes.gov.uk/zonemaps",
-      "exemptionUrl": "http://www.bathnes.gov.uk/BathCAZ",
+      "exemptionUrl": "http://www.bathnes.gov.uk/CAZexemptions",
       "activeChargeStartDate": "2018-10-28"
     }
   ]

--- a/src/it/resources/data/json/clean-air-zones.json
+++ b/src/it/resources/data/json/clean-air-zones.json
@@ -8,11 +8,11 @@
       "activeChargeStartDate": "2019-08-20"
     },
     {
-      "cleanAirZoneId": "39e54ed8-3ed2-441d-be3f-38fc9b70c8d3",
-      "name": "Leeds",
-      "boundaryUrl": "https://www.arcgis.com/home/webmap/viewer.html?webmap=de0120ae980b473982a3149ab072fdfc&extent=-1.733%2c53.7378%2c-1.333%2c53.8621",
-      "exemptionUrl": "https://exemption.leeds.gov.uk",
-      "activeChargeStartDate": "2019-07-20"
+      "cleanAirZoneId": "5dd5c926-ed33-4a0a-b911-46324433e866",
+      "name": "Bath",
+      "boundaryUrl": "http://www.bathnes.gov.uk/zonemaps",
+      "exemptionUrl": "http://www.bathnes.gov.uk/BathCAZ",
+      "activeChargeStartDate": "2018-10-28"
     }
   ]
 }

--- a/src/it/resources/data/json/sample-clean-air-zones.json
+++ b/src/it/resources/data/json/sample-clean-air-zones.json
@@ -10,11 +10,11 @@
       "directDebitEnabled": false
     },
     {
-      "cleanAirZoneId": "39e54ed8-3ed2-441d-be3f-38fc9b70c8d3",
-      "name": "Leeds",
-      "operatorName": "Leeds City Council",
-      "boundaryUrl": "https://www.arcgis.com/home/webmap/viewer.html?webmap=de0120ae980b473982a3149ab072fdfc&extent=-1.733%2c53.7378%2c-1.333%2c53.8621",
-      "exemptionUrl": "https://exemption.leeds.gov.uk",
+      "cleanAirZoneId": "5dd5c926-ed33-4a0a-b911-46324433e866",
+      "name": "Bath",
+      "operatorName": "Bath and North East Somerset Council",
+      "boundaryUrl": "http://www.bathnes.gov.uk/zonemaps",
+      "exemptionUrl": "http://www.bathnes.gov.uk/BathCAZ",
       "activeChargeStartDate": "2018-10-28",
       "directDebitEnabled": false
     }

--- a/src/it/resources/data/json/sample-clean-air-zones.json
+++ b/src/it/resources/data/json/sample-clean-air-zones.json
@@ -14,7 +14,7 @@
       "name": "Bath",
       "operatorName": "Bath and North East Somerset Council",
       "boundaryUrl": "http://www.bathnes.gov.uk/zonemaps",
-      "exemptionUrl": "http://www.bathnes.gov.uk/BathCAZ",
+      "exemptionUrl": "http://www.bathnes.gov.uk/CAZexemptions",
       "activeChargeStartDate": "2018-10-28",
       "directDebitEnabled": false
     }

--- a/src/it/resources/data/json/sample-tariff.json
+++ b/src/it/resources/data/json/sample-tariff.json
@@ -1,8 +1,8 @@
 {
-  "cleanAirZoneId": "dc1efcaf-a2cf-41ec-aa37-ea4b28a20a1d",
-  "name": "Leeds",
-  "tariffClass": "A",
-  "chargeIdentifier": "LCC01",
+  "cleanAirZoneId": "5dd5c926-ed33-4a0a-b911-46324433e866",
+  "name": "Bath",
+  "tariffClass": "C",
+  "chargeIdentifier": "BAC01",
   "rates": {
     "bus": 5.5,
     "car": 15.5,

--- a/src/it/resources/data/json/sample-tariff.json
+++ b/src/it/resources/data/json/sample-tariff.json
@@ -2,7 +2,7 @@
   "cleanAirZoneId": "5dd5c926-ed33-4a0a-b911-46324433e866",
   "name": "Bath",
   "tariffClass": "C",
-  "chargeIdentifier": "BAC01",
+  "chargeIdentifier": "BAT01",
   "rates": {
     "bus": 5.5,
     "car": 15.5,

--- a/src/it/resources/data/sql/sample-data.sql
+++ b/src/it/resources/data/sql/sample-data.sql
@@ -17,8 +17,8 @@ INSERT INTO public.T_CHARGE_DEFINITION (CHARGE_DEFINITION_ID, CAZ_NAME, CAZ_CLAS
                                         CLEAN_AIR_ZONE_ID, CHARGE_IDENTIFIER,
                                         ACTIVE_CHARGE_START_TIME, ACTIVE_CHARGE_END_TIME,
                                         CAZ_OPERATOR_NAME)
-VALUES (2, 'Leeds', 'B', '39e54ed8-3ed2-441d-be3f-38fc9b70c8d3', 'LCC01', '2019-07-20',
-        '2019-11-20', 'Leeds City Council');
+VALUES (2, 'Bath', 'C', '5dd5c926-ed33-4a0a-b911-46324433e866', 'BAT01', '2018-10-28',
+        '2019-11-20', 'Bath and North East Somerset Council');
 
 INSERT INTO public.T_TARIFF_DEFINITION (CHARGE_DEFINITION_ID, HGV_ENTRANT_FEE, CAR_ENTRANT_FEE,
                                         MINIBUS_ENTRANT_FEE, TAXI_ENTRANT_FEE, PHV_ENTRANT_FEE,
@@ -58,9 +58,9 @@ INSERT INTO public.T_CAZ_LINK_DETAIL (CHARGE_DEFINITION_ID,
                                       ADDITIONAL_INFO_URL,
                                       PUBLIC_TRANSPORT_OPTIONS_URL)
 VALUES (2,
-        'https://www.arcgis.com/home/webmap/viewer.html?webmap=de0120ae980b473982a3149ab072fdfc&extent=-1.733%2c53.7378%2c-1.333%2c53.8621',
-        'https://www.leeds.gov.uk/business/environmental-health-for-business/air-quality',
-        'https://exemption.leeds.gov.uk',
-        'https://www.leeds.gov.uk/business/environmental-health-for-business/air-quality/exempt-vehicles-clean-air-charging-zone',
-        'https://www.leeds.gov.uk/business/environmental-health-for-business/air-quality?utm_source=Clean_Air_Leeds_Website&utm_medium=referral&utm_term=What_Are_We_Doing',
-        'https://cleanairleeds.co.uk/what-can-i-do/residents');
+        'http://www.bathnes.gov.uk/zonemaps',
+        'http://www.bathnes.gov.uk/BathCAZ',
+        'http://www.bathnes.gov.uk/CAZexemptions',
+        'http://www.bathnes.gov.uk/CAZsupport',
+        'https://www.bathnes.gov.uk/bath-breathes-2021-overview',
+        'http://www.bathnes.gov.uk/cleanair4bathnes');

--- a/src/test/java/uk/gov/caz/tariff/controller/CleanAirZonesControllerTest.java
+++ b/src/test/java/uk/gov/caz/tariff/controller/CleanAirZonesControllerTest.java
@@ -129,11 +129,11 @@ class CleanAirZonesControllerTest {
         .build();
     Tariff tariff = Tariff.builder()
         .cleanAirZoneId(UUID.fromString(SOME_CLEAN_AIR_ZONE_ID))
-        .name("Leeds")
+        .name("Bath")
         .tariffClass('C')
         .informationUrls(informationUrls)
         .rates(rates)
-        .activeChargeStartDate("2020-04-23")
+        .activeChargeStartDate("2018-10-28")
         .build();
 
     return Optional.ofNullable(tariff);
@@ -149,10 +149,9 @@ class CleanAirZonesControllerTest {
                 MAIN_INFO_URL,
                 ACTIVE_CHARGE_START_DATE),
 
-            caz("Leeds", "39e54ed8-3ed2-441d-be3f-38fc9b70c8d3",
-                "https://www.arcgis.com/home/webmap/viewer.html?webmap="
-                    + "de0120ae980b473982a3149ab072fdfc&extent=-1.733%2c53.7378%2c-1.333%2c53.8621",
-                "https://exemption.leeds.gov.uk",
+            caz("Bath", "5dd5c926-ed33-4a0a-b911-46324433e866",
+                "http://www.bathnes.gov.uk/zonemaps",
+                "http://www.bathnes.gov.uk/CAZexemptions",
                 MAIN_INFO_URL,
                 ACTIVE_CHARGE_START_DATE)
         )).build();

--- a/src/test/java/uk/gov/caz/tariff/service/CleanAirZonesRepositoryTest.java
+++ b/src/test/java/uk/gov/caz/tariff/service/CleanAirZonesRepositoryTest.java
@@ -30,14 +30,14 @@ import uk.gov.caz.tariff.service.CleanAirZonesRepository.CleanAirZoneRowMapper;
 class CleanAirZonesRepositoryTest {
 
   private static final UUID SOME_CLEAN_AIR_ZONE_ID = UUID
-      .fromString("dc1efcaf-a2cf-41ec-aa37-ea4b28a20a1d");
+      .fromString("5dd5c926-ed33-4a0a-b911-46324433e866");
 
   private static final String SOME_URL = "www.test.uk";
   private static final String EXEMPTION_URL = "www.exemption.uk";
   private static final String MAIN_INFO_URL = "www.main.info";
 
-  private static final String LEEDS = "Leeds";
-  private static final String LEEDS_OPERATOR_NAME = "Leeds City Council";
+  private static final String BATH = "Bath";
+  private static final String BATH_OPERATOR_NAME = "Bath and North East Somerset Council";
 
   private static LocalDate ACTIVE_CHARGE_START_DATE = LocalDate.of(2018, 10, 28);
 
@@ -100,7 +100,7 @@ class CleanAirZonesRepositoryTest {
         String argument = answer.getArgument(0);
         switch (argument) {
           case "caz_name":
-            return LEEDS;
+            return BATH;
           case "boundary_url":
             return SOME_URL;
           case "exemption_url":
@@ -108,7 +108,7 @@ class CleanAirZonesRepositoryTest {
           case "main_info_url":
             return MAIN_INFO_URL;
           case "caz_operator_name":
-            return LEEDS_OPERATOR_NAME;
+            return BATH_OPERATOR_NAME;
         }
         throw new RuntimeException("Value not stubbed!");
       });
@@ -133,11 +133,10 @@ class CleanAirZonesRepositoryTest {
                 "https://exemptions.birmingham.gov.uk", MAIN_INFO_URL,
                 ACTIVE_CHARGE_START_DATE, "Birmingham City Council", false),
 
-            caz("Leeds", "39e54ed8-3ed2-441d-be3f-38fc9b70c8d3",
-                "https://www.arcgis.com/home/webmap/viewer.html?webmap="
-                    + "de0120ae980b473982a3149ab072fdfc&extent=-1.733%2c53.7378%2c-1.333%2c53.8621",
-                "https://exemptions.leeds.gov.uk", MAIN_INFO_URL,
-                ACTIVE_CHARGE_START_DATE, "Leeds City Council", true)
+            caz("Bath", "5dd5c926-ed33-4a0a-b911-46324433e866",
+                "http://www.bathnes.gov.uk/zonemaps",
+                "http://www.bathnes.gov.uk/CAZexemptions", MAIN_INFO_URL,
+                ACTIVE_CHARGE_START_DATE, "Bath and North East Somerset Council", true)
         )).build().getCleanAirZones();
   }
 
@@ -159,8 +158,8 @@ class CleanAirZonesRepositoryTest {
   private CleanAirZoneDto expectedCleanAirZone() {
     return CleanAirZoneDto.builder()
         .cleanAirZoneId(SOME_CLEAN_AIR_ZONE_ID)
-        .name(LEEDS)
-        .operatorName(LEEDS_OPERATOR_NAME)
+        .name(BATH)
+        .operatorName(BATH_OPERATOR_NAME)
         .boundaryUrl(URI.create(SOME_URL))
         .exemptionUrl(URI.create(EXEMPTION_URL))
         .mainInfoUrl(URI.create(MAIN_INFO_URL))

--- a/src/test/java/uk/gov/caz/tariff/service/TariffRepositoryTest.java
+++ b/src/test/java/uk/gov/caz/tariff/service/TariffRepositoryTest.java
@@ -34,9 +34,9 @@ class TariffRepositoryTest {
 
   private static final String SOME_URL = "www.test.uk";
 
-  private static final String SOME_CHARGE_IDENTIFIER = "LCC01";
+  private static final String SOME_CHARGE_IDENTIFIER = "BTH01";
 
-  private static final String LEEDS = "Leeds";
+  private static final String BATH = "Bath";
 
   @Mock
   private JdbcTemplate jdbcTemplate;
@@ -114,11 +114,11 @@ class TariffRepositoryTest {
         String argument = answer.getArgument(0);
         switch (argument) {
           case "caz_name":
-            return LEEDS;
+            return BATH;
           case "charge_identifier":
             return SOME_CHARGE_IDENTIFIER;
           case "caz_class":
-            return String.valueOf('C');
+            return String.valueOf('B');
           case "become_compliant_url":
           case "main_info_url":
           case "exemption_url":
@@ -169,7 +169,7 @@ class TariffRepositoryTest {
   private Tariff mockTariffInDB() {
     Tariff tariff = Tariff.builder()
         .cleanAirZoneId(SOME_CLEAN_AIR_ZONE_ID)
-        .name("Leeds")
+        .name("Bath")
         .build();
     when(jdbcTemplate.queryForObject(anyString(), any(TariffRowMapper.class), any())).thenReturn(
         tariff);
@@ -199,8 +199,8 @@ class TariffRepositoryTest {
         .build();
     return Tariff.builder()
         .cleanAirZoneId(SOME_CLEAN_AIR_ZONE_ID)
-        .name(LEEDS)
-        .tariffClass('C')
+        .name(BATH)
+        .tariffClass('B')
         .chargeIdentifier(SOME_CHARGE_IDENTIFIER)
         .rates(rates)
         .informationUrls(informationUrls)


### PR DESCRIPTION
All testing/build passing. All references to Leeds removed excepting those from Liquibase scripts that were reverted or overwritten as part of a previous work. 

![image](https://user-images.githubusercontent.com/43146680/105019164-b28caa00-5a3d-11eb-86cc-f94a806ac8e1.png)
