### PR TITLE
[CAZB-4424] Set PGAudit level to ALL,-READ

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3.3'
 
 services:
   postgres:
-    image: postgres:11-alpine
+    build: ./postgres-with-pgaudit
+    image: postgres-pgaudit-local:1
     container_name: postgres.docker
     ports:
       - 5432:5432

--- a/docker/postgres-with-pgaudit/Dockerfile
+++ b/docker/postgres-with-pgaudit/Dockerfile
@@ -1,0 +1,5 @@
+FROM postgres:11
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  postgresql-$PG_MAJOR-pgaudit
+
+CMD  ["postgres", "-c", "shared_preload_libraries=pgaudit"]

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,7 @@
             <id>start</id>
             <phase>pre-integration-test</phase>
             <goals>
+              <goal>build</goal>           
               <goal>start</goal>
             </goals>
           </execution>
@@ -336,6 +337,7 @@
             <phase>post-integration-test</phase>
             <goals>
               <goal>stop</goal>
+              <goal>remove</goal>              
             </goals>
 
           </execution>
@@ -346,7 +348,7 @@
           <autoCreateCustomNetworks>true</autoCreateCustomNetworks>
           <images>
             <image>
-              <alias>postgres-it</alias>
+              <alias>postgres-pgaudit-local</alias>
               <external>
                 <type>compose</type>
                 <basedir>src/it/resources</basedir>

--- a/src/it/resources/docker-compose-it.yml
+++ b/src/it/resources/docker-compose-it.yml
@@ -1,8 +1,9 @@
 version: '2' # only version 2.x is supported by the maven plugin
 
 services:
-  postgres-it:
-    image: postgres:11-alpine
+  postgres-pgaudit-local:
+    build: ../../../docker/postgres-with-pgaudit
+    image: postgres-pgaudit-local:1
     ports:
       # if you modify the port, remember to change it in application's configuration as well
       - 9999:5432

--- a/src/main/resources/db/changelog/changes/0026.1-0-update-pgaudit-level.yaml
+++ b/src/main/resources/db/changelog/changes/0026.1-0-update-pgaudit-level.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: 0026.1-0-update-pgaudit-level
+      author: informed
+      changes:
+        - sql:
+            comment: Uplift pgaudit to not log READ statements.
+            dbms: postgresql
+            endDelimiter: ;GO
+            splitStatements: true
+            sql: >-
+              CREATE EXTENSION if not exists pgaudit;
+              ALTER DATABASE "tariffs" set pgaudit.log = 'ALL, -READ';
+            stripComments: true

--- a/src/main/resources/db/changelog/changes/0026.1-0-update-pgaudit-level.yaml
+++ b/src/main/resources/db/changelog/changes/0026.1-0-update-pgaudit-level.yaml
@@ -2,6 +2,11 @@ databaseChangeLog:
   - changeSet:
       id: 0026.1-0-update-pgaudit-level
       author: informed
+      preConditions: # run this changeset unless we're in CI/CD
+        - onFail: MARK_RAN
+        - not:
+            changeLogPropertyDefined:
+              property: BUILD_ID # this env variable is set in CI execution environment
       changes:
         - sql:
             comment: Uplift pgaudit to not log READ statements.


### PR DESCRIPTION
## Brief summary
Set PGAudit level to ALL,-READ to avoid logging SELECT statements frequently issued by the application

## Implementation notes
No existing method changes as this is a database script only

## Testing
Tests have been performed to make sure this value is correctly interpreted by Postgres on the remote development environment prior to wrapping in a Liquibase script 

## JIRA ref
- [x] Is a JIRA ticket: (CAZB-4424)[https://eaflood.atlassian.net/browse/CAZB-4424]
- [ ] Part of a release: ()[]
